### PR TITLE
Add option for custom API URL

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,7 @@
     reloadButtonText: 'Reload',
     listPosition: 'bottom',
     autoRefresh: false,
+    customApiUrl: null,
     githubRepo: 'uberVU/github-changelog-playground',
     githubLabels: ['bug', 'enhancement', 'feature'],
     githubParams: {}
@@ -209,7 +210,11 @@
     },
 
     getGitHubIssuesUrl: function() {
-      return GITHUB_API_URL + '/repos/' + this.options.githubRepo + '/issues';
+      if (this.options.customApiUrl) {
+        return this.options.customApiUrl;
+      } else {
+        return GITHUB_API_URL + '/repos/' + this.options.githubRepo + '/issues';
+      }
     },
 
     getExpectedGitHubIssueLabel: function(issue) {


### PR DESCRIPTION
## Need

We need a way for users to use the plugin with a custom endpoint instead of `api.github.com`. This way they can route requests through a proxy.
## Deliverables

Modify the plugin to accept a custom API URL and use `api.github.com` by default
